### PR TITLE
Temp use axum server git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,20 +361,22 @@ dependencies = [
 [[package]]
 name = "axum-server"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447f28c85900215cc1bea282f32d4a2f22d55c5a300afdfbc661c8d6a632e063"
+source = "git+https://github.com/programatik29/axum-server#e575e90d1fc796401d144f306648553909336700"
 dependencies = [
  "arc-swap",
  "bytes",
  "futures-util",
- "http 0.2.11",
- "http-body 0.4.6",
- "hyper 0.14.27",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.0.1",
+ "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 2.0.0",
  "tokio",
  "tokio-rustls",
+ "tower",
  "tower-service",
 ]
 
@@ -2464,7 +2466,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2655,6 +2657,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7673e0aa20ee4937c6aacfc12bb8341cfbf054cdd21df6bec5fd0629fe9339b"
 
 [[package]]
 name = "rustls-webpki"
@@ -2948,7 +2966,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ argon2 = { version = "0.5", features = ["std", "zeroize"] }
 async-trait = "0.1"
 axum = { version = "0.7", features = ["http2"] }
 axum-extra = { version = "0.9", features = ["cookie", "typed-header"] }
-axum-server = { version = "0.5.1", features = ["tls-rustls"] }
+axum-server = { git = "https://github.com/programatik29/axum-server", features = ["tls-rustls"] }
+#axum-server = { version = "0.5.1", features = ["tls-rustls"] }
 base64 = "0.21"
 bincode = "1.3"
 cached = { version = "0.46", features = ["async_tokio_rt_multi_thread"] }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -423,9 +423,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-			"integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
@@ -446,9 +446,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-			"integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -580,12 +580,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
-			"integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+			"version": "1.40.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+			"integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.39.0"
+				"playwright": "1.40.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -595,9 +595,9 @@
 			}
 		},
 		"node_modules/@polka/url": {
-			"version": "1.0.0-next.23",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
-			"integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
+			"version": "1.0.0-next.24",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.24.tgz",
+			"integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==",
 			"dev": true
 		},
 		"node_modules/@sveltejs/adapter-auto": {
@@ -622,9 +622,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.27.5",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.27.5.tgz",
-			"integrity": "sha512-+L1WPs/ZYNjXoBFoFARypD4aZOjkT51vFpRCtQI45+Fmmfi4Y0dH/8VFlmYD6VlGe89ViIPg7lgf/JpGQ2tr7A==",
+			"version": "1.30.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.3.tgz",
+			"integrity": "sha512-0DzVXfU4h+tChFvoc8C61IqErCyskD4ydSIDjpKS2lYlEzIYrtYrY7juSqACFxqcvZAnOEXvSY+zZ8br0+ZMMg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -654,9 +654,9 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.5.2.tgz",
-			"integrity": "sha512-Dfy0Rbl+IctOVfJvWGxrX/3m6vxPLH8o0x+8FA5QEyMUQMo4kGOVIojjryU7YomBAexOTAuYf1RT7809yDziaA==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.5.3.tgz",
+			"integrity": "sha512-erhNtXxE5/6xGZz/M9eXsmI7Pxa6MS7jyTy06zN3Ck++ldrppOnOlJwHHTsMC7DHDQdgUp4NAc4cDNQ9eGdB/w==",
 			"dev": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^1.0.4",
@@ -705,9 +705,9 @@
 			"dev": true
 		},
 		"node_modules/@types/pug": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.9.tgz",
-			"integrity": "sha512-Yg4LkgFYvn1faISbDNWmcAC1XoDT8IoMUFspp5mnagKk+UvD2N0IWt5A7GRdMubsNWqgCLmrkf8rXkzNqb4szA==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
+			"integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
 			"dev": true
 		},
 		"node_modules/@ungap/structured-clone": {
@@ -1133,15 +1133,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-			"integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.3",
-				"@eslint/js": "8.53.0",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.55.0",
 				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -1212,9 +1212,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "2.35.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.35.0.tgz",
-			"integrity": "sha512-3WDFxNrkXaMlpqoNo3M1ZOQuoFLMO9+bdnN6oVVXaydXC7nzCJuGy9a0zqoNDHMSRPYt0Rqo6hIdHMEaI5sQnw==",
+			"version": "2.35.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.35.1.tgz",
+			"integrity": "sha512-IF8TpLnROSGy98Z3NrsKXWDSCbNY2ReHDcrYTuXZMbfX7VmESISR78TWgO9zdg4Dht1X8coub5jKwHzP0ExRug==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
@@ -1516,9 +1516,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.23.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-			"integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -1564,9 +1564,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -2068,12 +2068,12 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-			"integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+			"version": "1.40.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+			"integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.39.0"
+				"playwright-core": "1.40.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2086,9 +2086,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-			"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+			"version": "1.40.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+			"integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -2098,9 +2098,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"version": "8.4.32",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+			"integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2117,7 +2117,7 @@
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.6",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -2219,9 +2219,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-			"integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+			"integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -2234,9 +2234,9 @@
 			}
 		},
 		"node_modules/prettier-plugin-svelte": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.1.0.tgz",
-			"integrity": "sha512-96+AZxs2ESqIFA9j+o+DHqY+BsUglezfl553LQd6VOtTyJq5GPuBEb3ElxF2cerFzKlYKttlH/VcVmRNj5oc3A==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.1.2.tgz",
+			"integrity": "sha512-7xfMZtwgAWHMT0iZc8jN4o65zgbAQ3+O32V6W7pXrqNvKnHnkoyQCGCbKeUyXKZLbYE0YhFRnamfxfkEGxm8qA==",
 			"dev": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
@@ -2528,9 +2528,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.3.tgz",
-			"integrity": "sha512-sqmG9KC6uUc7fb3ZuWoxXvqk6MI9Uu4ABA1M0fYDgTlFYu1k02xp96u6U9+yJZiVm84m9zge7rrA/BNZdFpOKw==",
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.8.tgz",
+			"integrity": "sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
@@ -2552,9 +2552,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.0.tgz",
-			"integrity": "sha512-8VfqhfuRJ1sKW+o8isH2kPi0RhjXH1nNsIbCFGyoUHG+ZxVxHYRKcb+S8eaL/1tyj3VGvWYx3Y5+oCUsJgnzcw==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.2.tgz",
+			"integrity": "sha512-E6iFh4aUCGJLRz6QZXH3gcN/VFfkzwtruWSRmlKrLWQTiO6VzLsivR6q02WYLGNAGecV3EocqZuCDrC2uttZ0g==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -2613,9 +2613,9 @@
 			}
 		},
 		"node_modules/svelte-preprocess": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.0.tgz",
-			"integrity": "sha512-EkErPiDzHAc0k2MF5m6vBNmRUh338h2myhinUw/xaqsLs7/ZvsgREiLGj03VrSzbY/TB5ZXgBOsKraFee5yceA==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.2.tgz",
+			"integrity": "sha512-XF0aliMAcYnP4hLETvB6HRAMnaL09ASYT1Z2I1Gwu0nz6xbdg/dSgAEthtFZJA4AKrNhFDFdmUDO+H9d/6xg5g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -2633,7 +2633,7 @@
 				"coffeescript": "^2.5.1",
 				"less": "^3.11.3 || ^4.0.0",
 				"postcss": "^7 || ^8",
-				"postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0",
+				"postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
 				"pug": "^3.0.0",
 				"sass": "^1.26.8",
 				"stylus": "^0.55.0",
@@ -2760,9 +2760,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -2917,9 +2917,9 @@
 			}
 		},
 		"node_modules/yup": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/yup/-/yup-1.3.2.tgz",
-			"integrity": "sha512-6KCM971iQtJ+/KUaHdrhVr2LDkfhBtFPRnsG1P8F4q3uUVQ2RfEM9xekpha9aA4GXWJevjM10eDcPQ1FfWlmaQ==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/yup/-/yup-1.3.3.tgz",
+			"integrity": "sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==",
 			"dev": true,
 			"dependencies": {
 				"property-expr": "^2.0.5",
@@ -3128,9 +3128,9 @@
 			"dev": true
 		},
 		"@eslint/eslintrc": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-			"integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
@@ -3145,9 +3145,9 @@
 			}
 		},
 		"@eslint/js": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-			"integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
 			"dev": true
 		},
 		"@fastify/busboy": {
@@ -3245,18 +3245,18 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
-			"integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+			"version": "1.40.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+			"integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.39.0"
+				"playwright": "1.40.1"
 			}
 		},
 		"@polka/url": {
-			"version": "1.0.0-next.23",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
-			"integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
+			"version": "1.0.0-next.24",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.24.tgz",
+			"integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==",
 			"dev": true
 		},
 		"@sveltejs/adapter-auto": {
@@ -3276,9 +3276,9 @@
 			"requires": {}
 		},
 		"@sveltejs/kit": {
-			"version": "1.27.5",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.27.5.tgz",
-			"integrity": "sha512-+L1WPs/ZYNjXoBFoFARypD4aZOjkT51vFpRCtQI45+Fmmfi4Y0dH/8VFlmYD6VlGe89ViIPg7lgf/JpGQ2tr7A==",
+			"version": "1.30.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.3.tgz",
+			"integrity": "sha512-0DzVXfU4h+tChFvoc8C61IqErCyskD4ydSIDjpKS2lYlEzIYrtYrY7juSqACFxqcvZAnOEXvSY+zZ8br0+ZMMg==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^2.5.0",
@@ -3297,9 +3297,9 @@
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.5.2.tgz",
-			"integrity": "sha512-Dfy0Rbl+IctOVfJvWGxrX/3m6vxPLH8o0x+8FA5QEyMUQMo4kGOVIojjryU7YomBAexOTAuYf1RT7809yDziaA==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.5.3.tgz",
+			"integrity": "sha512-erhNtXxE5/6xGZz/M9eXsmI7Pxa6MS7jyTy06zN3Ck++ldrppOnOlJwHHTsMC7DHDQdgUp4NAc4cDNQ9eGdB/w==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^1.0.4",
@@ -3333,9 +3333,9 @@
 			"dev": true
 		},
 		"@types/pug": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.9.tgz",
-			"integrity": "sha512-Yg4LkgFYvn1faISbDNWmcAC1XoDT8IoMUFspp5mnagKk+UvD2N0IWt5A7GRdMubsNWqgCLmrkf8rXkzNqb4szA==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
+			"integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
 			"dev": true
 		},
 		"@ungap/structured-clone": {
@@ -3656,15 +3656,15 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-			"integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.3",
-				"@eslint/js": "8.53.0",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.55.0",
 				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -3716,9 +3716,9 @@
 			"requires": {}
 		},
 		"eslint-plugin-svelte": {
-			"version": "2.35.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.35.0.tgz",
-			"integrity": "sha512-3WDFxNrkXaMlpqoNo3M1ZOQuoFLMO9+bdnN6oVVXaydXC7nzCJuGy9a0zqoNDHMSRPYt0Rqo6hIdHMEaI5sQnw==",
+			"version": "2.35.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.35.1.tgz",
+			"integrity": "sha512-IF8TpLnROSGy98Z3NrsKXWDSCbNY2ReHDcrYTuXZMbfX7VmESISR78TWgO9zdg4Dht1X8coub5jKwHzP0ExRug==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
@@ -3940,9 +3940,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.23.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-			"integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
@@ -3979,9 +3979,9 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true
 		},
 		"import-fresh": {
@@ -4356,28 +4356,28 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-			"integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+			"version": "1.40.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+			"integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.39.0"
+				"playwright-core": "1.40.1"
 			}
 		},
 		"playwright-core": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-			"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+			"version": "1.40.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+			"integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"version": "8.4.32",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+			"integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.3.6",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -4423,15 +4423,15 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-			"integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+			"integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
 			"dev": true
 		},
 		"prettier-plugin-svelte": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.1.0.tgz",
-			"integrity": "sha512-96+AZxs2ESqIFA9j+o+DHqY+BsUglezfl553LQd6VOtTyJq5GPuBEb3ElxF2cerFzKlYKttlH/VcVmRNj5oc3A==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.1.2.tgz",
+			"integrity": "sha512-7xfMZtwgAWHMT0iZc8jN4o65zgbAQ3+O32V6W7pXrqNvKnHnkoyQCGCbKeUyXKZLbYE0YhFRnamfxfkEGxm8qA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -4626,9 +4626,9 @@
 			}
 		},
 		"svelte": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.3.tgz",
-			"integrity": "sha512-sqmG9KC6uUc7fb3ZuWoxXvqk6MI9Uu4ABA1M0fYDgTlFYu1k02xp96u6U9+yJZiVm84m9zge7rrA/BNZdFpOKw==",
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.8.tgz",
+			"integrity": "sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==",
 			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "^2.2.1",
@@ -4647,9 +4647,9 @@
 			}
 		},
 		"svelte-check": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.0.tgz",
-			"integrity": "sha512-8VfqhfuRJ1sKW+o8isH2kPi0RhjXH1nNsIbCFGyoUHG+ZxVxHYRKcb+S8eaL/1tyj3VGvWYx3Y5+oCUsJgnzcw==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.2.tgz",
+			"integrity": "sha512-E6iFh4aUCGJLRz6QZXH3gcN/VFfkzwtruWSRmlKrLWQTiO6VzLsivR6q02WYLGNAGecV3EocqZuCDrC2uttZ0g==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -4683,9 +4683,9 @@
 			"requires": {}
 		},
 		"svelte-preprocess": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.0.tgz",
-			"integrity": "sha512-EkErPiDzHAc0k2MF5m6vBNmRUh338h2myhinUw/xaqsLs7/ZvsgREiLGj03VrSzbY/TB5ZXgBOsKraFee5yceA==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.2.tgz",
+			"integrity": "sha512-XF0aliMAcYnP4hLETvB6HRAMnaL09ASYT1Z2I1Gwu0nz6xbdg/dSgAEthtFZJA4AKrNhFDFdmUDO+H9d/6xg5g==",
 			"dev": true,
 			"requires": {
 				"@types/pug": "^2.0.6",
@@ -4765,9 +4765,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true
 		},
 		"undici": {
@@ -4847,9 +4847,9 @@
 			"dev": true
 		},
 		"yup": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/yup/-/yup-1.3.2.tgz",
-			"integrity": "sha512-6KCM971iQtJ+/KUaHdrhVr2LDkfhBtFPRnsG1P8F4q3uUVQ2RfEM9xekpha9aA4GXWJevjM10eDcPQ1FfWlmaQ==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/yup/-/yup-1.3.3.tgz",
+			"integrity": "sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==",
 			"dev": true,
 			"requires": {
 				"property-expr": "^2.0.5",

--- a/src/server.rs
+++ b/src/server.rs
@@ -201,29 +201,20 @@ pub async fn run_server(level: &str) -> Result<(), anyhow::Error> {
         let addr = SocketAddr::from(([0, 0, 0, 0], ports.http));
         info!("Server listening on {}", addr);
 
-        let listener = TcpListener::bind(addr)
-            .await
-            .expect("Cannot bind to HTTP port");
-        // TODO update to shutdown handle again
-        axum::serve(listener, routes_sealed)
-            // axum_server::bind(addr)
-            //     .handle(shutdown_handle)
-            //     .serve(routes_sealed.into_make_service())
+        axum_server::bind(addr)
+            .handle(shutdown_handle)
+            .serve(routes_sealed.into_make_service())
             .await
             .expect("Starting the axum sealed server");
     } else {
         let addr = SocketAddr::from(([0, 0, 0, 0], ports.https));
         info!("Server listening on {}", addr);
 
-        todo!("TLS listener binding with axum 0.7");
-        // let listener = TcpListener::bind(addr)
-        //     .await
-        //     .expect("Cannot bind to HTTPS port");
-        // axum_server::bind_rustls(addr, tls_config_unseal)
-        //     .handle(shutdown_handle)
-        //     .serve(routes_sealed.into_make_service())
-        //     .await
-        //     .expect("Starting the axum sealed server");
+        axum_server::bind_rustls(addr, tls_config_unseal)
+            .handle(shutdown_handle)
+            .serve(routes_sealed.into_make_service())
+            .await
+            .expect("Starting the axum sealed server");
     }
 
     let enc_keys = rx_enc_keys.recv_async().await?;
@@ -339,20 +330,18 @@ pub async fn run_server(level: &str) -> Result<(), anyhow::Error> {
         let addr = SocketAddr::from(([0, 0, 0, 0], ports.http));
         info!("Server listening on {}", addr);
 
-        let listener = TcpListener::bind(addr).await.expect("Cannot bind to port");
-        axum::serve(listener, routes)
+        axum_server::bind(addr)
+            .serve(routes.into_make_service())
             .await
             .expect("Starting the axum server");
     } else {
         let addr = SocketAddr::from(([0, 0, 0, 0], ports.https));
         info!("Server listening on {}", addr);
 
-        todo!("TLS listener binding with axum 0.7");
-        // let listener = TcpListener::bind(addr).await.expect("Cannot bind to port");
-        // axum_server::bind_rustls(addr, tls_config)
-        //     .serve(routes.into_make_service())
-        //     .await
-        //     .expect("Starting the axum server");
+        axum_server::bind_rustls(addr, tls_config)
+            .serve(routes.into_make_service())
+            .await
+            .expect("Starting the axum server");
     }
 
     Ok(())


### PR DESCRIPTION
A temporary switch to the axum_server git repo until a new release has been pushed to crates.io.
This is necessary to make the switch to axum 0.7 and hyper 1.0.
Will be reverted as soon as the next stable release is out.