### PR TITLE
add Unknown to Flows enum

### DIFF
--- a/src/oidc/validation.rs
+++ b/src/oidc/validation.rs
@@ -185,6 +185,8 @@ pub enum Flows {
     client_credentials,
     password,
     refresh_token,
+    #[serde(other)]
+    Unknown,
 }
 
 /// Used internally to cache token validation requests for a short amount of time


### PR DESCRIPTION
workaround for:

ERROR nioca::routes::oidc: OIDC automatic config lookup failure: error decoding response body: unknown variant `urn:ietf:params:oauth:grant-type:device_code`, expected one of `authorization_code`, `client_credentials`, `password`, `refresh_token` at line 1 column 682

like here:
https://github.com/ramosbugs/openidconnect-rs/issues/7
