### PR TITLE
change uid to email

### DIFF
--- a/src/oidc/principal.rs
+++ b/src/oidc/principal.rs
@@ -41,7 +41,7 @@ impl PrincipalOidc {
         };
 
         Ok(Self {
-            id: claims.uid,
+            id: claims.email,
             preferred_username: claims.preferred_username,
             subject: claims.sub,
             roles,
@@ -184,7 +184,7 @@ pub struct JwtAccessClaims {
     pub scope: String,
     pub allowed_origins: Option<Vec<String>>,
     // user part
-    pub uid: String,
+    pub email: String,
     pub preferred_username: Option<String>,
     pub roles: Option<Vec<String>>,
     pub groups: Option<Vec<String>>,
@@ -211,7 +211,7 @@ pub struct JwtIdClaims {
 pub struct JwtRefreshClaims {
     pub azp: String,
     pub typ: JwtType,
-    pub uid: String,
+    pub email: String,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]


### PR DESCRIPTION
workaround for sso with rauthy:

2025-03-19T09:40:23.417482Z ERROR nioca::oidc: Error deserializing JWT Token claims: missing field `uid` at line 1 column 284

might need a proper fix.

Might be caused by these changes?

https://github.com/sebadob/rauthy/pull/264